### PR TITLE
Bug fix for hi-res images using in imageView

### DIFF
--- a/OnboardKit/OnboardPageViewController.swift
+++ b/OnboardKit/OnboardPageViewController.swift
@@ -44,7 +44,7 @@ internal final class OnboardPageViewController: UIViewController {
   private lazy var imageView: UIImageView = {
     let imageView = UIImageView()
     imageView.translatesAutoresizingMaskIntoConstraints = false
-    imageView.contentMode = .center
+    imageView.contentMode = .scaleAspectFit
     return imageView
   }()
 


### PR DESCRIPTION
`imageView.contentMode` should be changed to `.scaleAspectFit` in order to be able to use hi-res images or to customize the imageView height by adjusting multiplier value in
`imageView.heightAnchor.constraint(equalTo: pageStackView.heightAnchor, multiplier: 0.5)`

If we have `imageView.contentMode = .center` and use hi-res image, the stack renders completely broken.

![onboardkit before bug fix 500](https://user-images.githubusercontent.com/45120599/48965184-5eccd480-f01d-11e8-980e-2080189938f9.png) ![onboardkit after bug fix 500](https://user-images.githubusercontent.com/45120599/48965173-2e853600-f01d-11e8-9bcb-7bbf621664af.png)




