### PR TITLE
Expose imageview contentmode

### DIFF
--- a/OnboardKit/OnboardPageViewController.swift
+++ b/OnboardKit/OnboardPageViewController.swift
@@ -44,7 +44,6 @@ internal final class OnboardPageViewController: UIViewController {
   private lazy var imageView: UIImageView = {
     let imageView = UIImageView()
     imageView.translatesAutoresizingMaskIntoConstraints = false
-    imageView.contentMode = .center
     return imageView
   }()
 
@@ -90,6 +89,8 @@ internal final class OnboardPageViewController: UIViewController {
 
   private func customizeStyleWith(_ appearanceConfiguration: OnboardViewController.AppearanceConfiguration) {
     view.backgroundColor = appearanceConfiguration.backgroundColor
+    // Setup imageView
+    imageView.contentMode = appearanceConfiguration.imageContentMode
     // Style title
     titleLabel.textColor = appearanceConfiguration.titleColor
     titleLabel.font = appearanceConfiguration.titleFont

--- a/OnboardKit/OnboardViewController.swift
+++ b/OnboardKit/OnboardViewController.swift
@@ -170,6 +170,11 @@ public extension OnboardViewController {
     /// - note: Defualts to white
     let backgroundColor: UIColor
 
+    /// The `contentMode` used for the slide imageView
+    ///
+    /// - note: Defualts to white
+    let imageContentMode: UIView.ContentMode
+
     /// The font used for the title and action button
     ///
     /// - note: Defualts to preferred text style `.title1` (supports dinamyc type)
@@ -194,6 +199,7 @@ public extension OnboardViewController {
                 titleColor: UIColor? = nil,
                 textColor: UIColor = .darkText,
                 backgroundColor: UIColor = .white,
+                imageContentMode: UIView.ContentMode = .center,
                 titleFont: UIFont = UIFont.preferredFont(forTextStyle: .title1),
                 textFont: UIFont = UIFont.preferredFont(forTextStyle: .body),
                 advanceButtonStyling: ButtonStyling? = nil,
@@ -202,6 +208,7 @@ public extension OnboardViewController {
       self.titleColor = titleColor ?? textColor
       self.textColor = textColor
       self.backgroundColor = backgroundColor
+      self.imageContentMode = imageContentMode
       self.titleFont = titleFont
       self.textFont = textFont
       self.advanceButtonStyling = advanceButtonStyling

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ let appearance = AppearanceConfiguration(tintColor: .orange,
                                          titleColor: .red,
                                          textColor: .white,
                                          backgroundColor: .black,
+                                         imageContentMode: .scaleAspectFit,
                                          titleFont: UIFont.boldSystemFont(ofSize: 32.0),
                                          textFont: UIFont.boldSystemFont(ofSize: 17.0))
 ````
@@ -78,6 +79,17 @@ let appearance = AppearanceConfiguration(tintColor: .orange,
 let onboardingVC = OnboardViewController(pageItems: onboardingPages,
                                          appearanceConfiguration: appearance)
 ````
+
+##### List of customizable properties:
+- `tintColor` - used for tinting the advance and action buttons
+- `titleColor` - used to set title color (textColor is used if not specified)
+- `textColor` - used to set description text color
+- `backgroundColor` - used to set view background color
+- `imageContentMode` - used to set the content mode of page imageViews
+- `titleFont` - used to set the title font (used for the action button font as well) 
+- `textFont` - used to set the description text font (used for the advance button font as well)
+- `advanceButtonStyling` - a block used to customize the advance button
+- `actionButtonStyling` - a block used to customize the action button
 
 #### Customizing Buttons
 To customize the style of the advance and action buttons on each page of the onboarding flow, you can use a `ButtonStyling` closure.


### PR DESCRIPTION
By popular demand exposed `contentMode` for the imageView of the OnboardPage.
It can be set in the `AppearanceConfiguration`.

Updated `README` with a list of all customizable properties.